### PR TITLE
Implement feeding options with extra data

### DIFF
--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -2,6 +2,7 @@
 @using BabyNanny.Models
 @using System.Timers;
 @using BabyNanny.Helpers;
+@using System.Linq;
 @inject IConnectivity ConnectivityService;
 @inject NavigationManager NavigationManager;
 @inject IDialogService DialogService;
@@ -21,7 +22,7 @@
             </h6>
 
         </div>
-        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" OnClick="@(() => ActionClick(BabyNannyRepository.ActionTypes.Sleeping))">
+        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" OnClick="@(async () => await ActionClick(BabyNannyRepository.ActionTypes.Sleeping))">
             @BtnSleepText
         </TelerikButton>
     </div>
@@ -39,7 +40,7 @@
             </h6>
 
         </div>
-        <TelerikButton Id="btnDiaper" Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" OnClick="@(() => ActionClick(BabyNannyRepository.ActionTypes.Diaper))">
+        <TelerikButton Id="btnDiaper" Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" OnClick="@(async () => await ActionClick(BabyNannyRepository.ActionTypes.Diaper))">
             @BtnDiaperText
         </TelerikButton>
     </div>
@@ -56,7 +57,7 @@
                 @TxtFeedProgress
             </h6>
         </div>
-        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" OnClick="@(() => ActionClick(BabyNannyRepository.ActionTypes.Feeding))">
+        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" OnClick="@(async () => await ActionClick(BabyNannyRepository.ActionTypes.Feeding))">
             @BtnFeedText
         </TelerikButton>
     </div>
@@ -118,74 +119,123 @@
     private BabyAction? _lastAction;
 
 
-    void ActionClick(BabyNannyRepository.ActionTypes actionType)
+    async Task ActionClick(BabyNannyRepository.ActionTypes actionType)
     {
+        if (actionType == BabyNannyRepository.ActionTypes.Feeding)
+        {
+            await HandleFeedingAction();
+            return;
+        }
+
         var lastAction = GetLastAction(actionType);
         var actionText = actionType switch
         {
-            BabyNannyRepository.ActionTypes.Feeding => "Feeding",
             BabyNannyRepository.ActionTypes.Sleeping => "Sleep",
             BabyNannyRepository.ActionTypes.Diaper => "Diaper",
             _ => throw new ArgumentOutOfRangeException(nameof(actionType), actionType, null)
         };
 
         var isStopping = lastAction is { Stopped: null };
-        lastAction = isStopping
-            ? StopAction(lastAction!)
-            : AddAction(actionType);
+        lastAction = isStopping ? StopAction(lastAction!) : AddAction(actionType);
         if (lastAction == null)
             return;
 
-        // var actionStatus = isStopping ? "Stopped" : "Started";
-
-        // var timestamp = isStopping ? TimeDifference(lastAction.Started, lastAction.Stopped) : "";
-
         switch (actionType)
         {
-            case BabyNannyRepository.ActionTypes.Feeding:
-                TxtFeed = $"{actionText}";
-                TxtFeedProgress = isStopping ? "a few seconds ago" : "In Progress";
-                BtnFeedText = isStopping ? "Start" : "Stop";
-
-                break;
             case BabyNannyRepository.ActionTypes.Sleeping:
                 TxtSleep = $"{actionText}";
                 TxtSleepProgress = isStopping ? "a few seconds ago" : "In Progress";
                 BtnSleepText = isStopping ? "Start" : "Stop";
-
                 break;
             case BabyNannyRepository.ActionTypes.Diaper:
-                // txtDiaper = $"{actionText}";
                 TxtDiaperProgress = isStopping ? "a few seconds ago" : "In Progress";
-
-                // btnDiaperText = isStopping ? "Start" : "Stop";
                 break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(actionType), actionType, null);
         }
 
         if (isStopping)
         {
             if (lastAction != null) LstActivityActions?.Add(lastAction);
-            // Trigger re-rendering of the component
             InvokeAsync(StateHasChanged);
         }
 
         if (actionType != BabyNannyRepository.ActionTypes.Diaper)
         {
             if (isStopping)
-            {
                 StopTimer();
-            }
             else
-            {
                 StartTimer(lastAction);
-            }
         }
         else
         {
             if (lastAction != null) StopAction(lastAction);
         }
+    }
+
+    private async Task HandleFeedingAction()
+    {
+        var lastAction = GetLastAction(BabyNannyRepository.ActionTypes.Feeding);
+        var isStopping = lastAction is { Stopped: null };
+
+        if (isStopping)
+        {
+            lastAction = StopAction(lastAction!);
+            TxtFeed = "Feeding";
+            TxtFeedProgress = "a few seconds ago";
+            BtnFeedText = "Start";
+            if (lastAction != null) LstActivityActions?.Add(lastAction);
+            StopTimer();
+            InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        var option = await DialogService.DisplayActionSheet("Feeding", "Cancel", null, "Bottle", "Meal", "Left Breast", "Right Breast");
+        if (string.IsNullOrEmpty(option) || option == "Cancel")
+            return;
+
+        var feedType = option switch
+        {
+            "Bottle" => BabyAction.FeedingTypes.Bottle,
+            "Meal" => BabyAction.FeedingTypes.Meal,
+            "Left Breast" => BabyAction.FeedingTypes.LeftBreast,
+            _ => BabyAction.FeedingTypes.RightBreast
+        };
+
+        if (LstChildren == null) return;
+        var action = new BabyAction
+        {
+            Type = (int)BabyNannyRepository.ActionTypes.Feeding,
+            Started = DateTime.Now,
+            ChildId = LstChildren[0].Id,
+            FeedingType = feedType
+        };
+        App.BabyNannyRepository?.AddAction(action);
+        LstActions?.Add(action);
+        LstActions = LstActions?.OrderByDescending(x => x.Started).ToList();
+        _lastAction = action;
+
+        TxtFeed = "Feeding";
+        TxtFeedProgress = "In Progress";
+        BtnFeedText = "Stop";
+
+        StartTimer(action);
+
+        if (feedType == BabyAction.FeedingTypes.Bottle)
+        {
+            var amount = await DialogService.DisplayPrompt("Amount", "Amount (ml)");
+            if (int.TryParse(amount, out var ml))
+                action.AmountML = ml;
+            var bottle = await DialogService.DisplayActionSheet("Bottle Type", "Cancel", null, "Breast Milk", "Formula");
+            if (!string.IsNullOrEmpty(bottle) && bottle != "Cancel")
+                action.BottleType = bottle;
+        }
+        else if (feedType == BabyAction.FeedingTypes.Meal)
+        {
+            var desc = await DialogService.DisplayPrompt("Meal", "Description");
+            if (!string.IsNullOrWhiteSpace(desc))
+                action.MealDescription = desc;
+        }
+
+        App.BabyNannyRepository?.EditAction(action);
     }
 
     private BabyAction? GetLastAction(BabyNannyRepository.ActionTypes type)

--- a/BabyNanny/Data/BabyNannyRepository.cs
+++ b/BabyNanny/Data/BabyNannyRepository.cs
@@ -1,6 +1,7 @@
 ﻿using BabyNanny.Models;
 using SQLite;
 using SQLiteNetExtensions.Extensions;
+using System.Linq;
 
 namespace BabyNanny.Data
 {
@@ -13,6 +14,17 @@ namespace BabyNanny.Data
             _connection = new SQLiteConnection(dbPath);
             _connection.CreateTable<Child>();
             _connection.CreateTable<BabyAction>();
+
+            var tableInfo = _connection.GetTableInfo(nameof(BabyAction));
+            var columns = tableInfo.Select(c => c.Name).ToList();
+            if (!columns.Contains(nameof(BabyAction.FeedingType)))
+                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.FeedingType)} INTEGER");
+            if (!columns.Contains(nameof(BabyAction.AmountML)))
+                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.AmountML)} INTEGER");
+            if (!columns.Contains(nameof(BabyAction.BottleType)))
+                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.BottleType)} TEXT");
+            if (!columns.Contains(nameof(BabyAction.MealDescription)))
+                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.MealDescription)} TEXT");
         }
 
         #region Child

--- a/BabyNanny/Data/DialogService.cs
+++ b/BabyNanny/Data/DialogService.cs
@@ -11,5 +11,10 @@
         {
             return await Application.Current!.Windows[0].Page!.DisplayAlert(title,message,accept,cancel);
         }
+
+        public async Task<string?> DisplayActionSheet(string title,string cancel,string destruction, params string[] buttons)
+        {
+            return await Application.Current!.Windows[0].Page!.DisplayActionSheet(title, cancel, destruction, buttons);
+        }
     }
 }

--- a/BabyNanny/Data/IDialogService.cs
+++ b/BabyNanny/Data/IDialogService.cs
@@ -4,4 +4,5 @@ internal interface IDialogService
 {
     Task<string> DisplayPrompt(string title,string message);
     Task<bool> DisplayAlert(string title,string message,string accept ,string cancel);
+    Task<string?> DisplayActionSheet(string title,string cancel,string destruction, params string[] buttons);
 }

--- a/BabyNanny/Models/BabyAction.cs
+++ b/BabyNanny/Models/BabyAction.cs
@@ -12,14 +12,27 @@ namespace BabyNanny.Models
     [Table("BabyAction")]
     public class BabyAction
     {
+        public enum FeedingTypes
+        {
+            Bottle,
+            Meal,
+            LeftBreast,
+            RightBreast
+        }
+
         [PrimaryKey, AutoIncrement, Column("Id")]
         public int Id { get; set; }
         public int Type { get; set; }
         public DateTime? Started { get; set; }
         public DateTime? Stopped { get; set; }
 
+        public FeedingTypes? FeedingType { get; set; }
+        public int? AmountML { get; set; }
+        public string? BottleType { get; set; }
+        public string? MealDescription { get; set; }
+
         [ForeignKey(typeof(Child))]
         public int ChildId { get; set; }
-     
+
     }
 }


### PR DESCRIPTION
## Summary
- expand `BabyAction` to store feeding details
- update repository to add new database columns
- extend dialog service with action sheet helper
- prompt for feeding type and details in UI

## Testing
- `dotnet build` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509f9a34748320be544b410936cfec