### PR TITLE
Update TimeDifference formatting

### DIFF
--- a/BabyNanny.Tests/TimeDifferenceTests.cs
+++ b/BabyNanny.Tests/TimeDifferenceTests.cs
@@ -21,7 +21,7 @@ namespace BabyNanny.Tests
             var start = new DateTime(2024, 1, 1, 0, 0, 0);
             var end = start.AddMinutes(2).AddSeconds(30);
             var result = TimeUtils.TimeDifference(start, end);
-            Assert.Equal("2m 30s", result);
+            Assert.Equal("2m", result);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace BabyNanny.Tests
                 .AddMinutes(5)
                 .AddSeconds(6);
             var result = TimeUtils.TimeDifference(start, end);
-            Assert.Equal("1M 3d 4h 5m 6s", result);
+            Assert.Equal("1M 3d", result);
         }
     }
 }

--- a/BabyNanny/Helpers/TimeUtils.cs
+++ b/BabyNanny/Helpers/TimeUtils.cs
@@ -25,11 +25,27 @@ namespace BabyNanny.Helpers
             var seconds = timeSpan.Seconds;
 
             var result = new List<string>();
-            if (months > 0) result.Add($"{months}M");
-            if (days > 0) result.Add($"{days}d");
-            if (hours > 0) result.Add($"{hours}h");
-            if (minutes > 0) result.Add($"{minutes}m");
-            if (seconds > 0) result.Add($"{seconds}s");
+
+            if (months > 0)
+                result.Add($"{months}M");
+
+            if (days > 0)
+                result.Add($"{days}d");
+
+            if (months == 0)
+            {
+                if (hours > 0)
+                    result.Add($"{hours}h");
+
+                if (days == 0)
+                {
+                    if (minutes > 0)
+                        result.Add($"{minutes}m");
+
+                    if (timeSpan.TotalMinutes < 1 && seconds > 0)
+                        result.Add($"{seconds}s");
+                }
+            }
 
             return string.Join(" ", result);
         }


### PR DESCRIPTION
## Summary
- adjust the time display logic to omit seconds/minutes/hours when larger units are present
- update unit tests to match the new formatting rules

## Testing
- `dotnet restore BabyNanny.Tests/BabyNanny.Tests.csproj`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj --no-build` *(fails: "The argument ... is invalid")*

------
https://chatgpt.com/codex/tasks/task_e_6852bf63ef2c8320ab97735020c04592