### PR TITLE
Add diaper type logging support

### DIFF
--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -126,12 +126,16 @@
             await HandleFeedingAction();
             return;
         }
+        if (actionType == BabyNannyRepository.ActionTypes.Diaper)
+        {
+            await HandleDiaperAction();
+            return;
+        }
 
         var lastAction = GetLastAction(actionType);
         var actionText = actionType switch
         {
             BabyNannyRepository.ActionTypes.Sleeping => "Sleep",
-            BabyNannyRepository.ActionTypes.Diaper => "Diaper",
             _ => throw new ArgumentOutOfRangeException(nameof(actionType), actionType, null)
         };
 
@@ -147,9 +151,6 @@
                 TxtSleepProgress = isStopping ? "a few seconds ago" : "In Progress";
                 BtnSleepText = isStopping ? "Start" : "Stop";
                 break;
-            case BabyNannyRepository.ActionTypes.Diaper:
-                TxtDiaperProgress = isStopping ? "a few seconds ago" : "In Progress";
-                break;
         }
 
         if (isStopping)
@@ -158,29 +159,10 @@
             InvokeAsync(StateHasChanged);
         }
 
-        if (actionType != BabyNannyRepository.ActionTypes.Diaper)
-        {
-            if (isStopping)
-                StopTimer();
-            else
-                StartTimer(lastAction);
-        }
+        if (isStopping)
+            StopTimer();
         else
-        {
-            if (lastAction != null)
-            {
-                if (!isStopping)
-                {
-                    lastAction = StopAction(lastAction);
-                    LstActivityActions?.Add(lastAction);
-                    InvokeAsync(StateHasChanged);
-                }
-                else
-                {
-                    StopAction(lastAction);
-                }
-            }
-        }
+            StartTimer(lastAction);
     }
 
     private async Task HandleFeedingAction()
@@ -248,6 +230,24 @@
         }
 
         App.BabyNannyRepository?.EditAction(action);
+    }
+
+    private async Task HandleDiaperAction()
+    {
+        var option = await DialogService.DisplayActionSheet("Diaper", "Cancel", null, "Pee", "Poo", "Both");
+        if (string.IsNullOrEmpty(option) || option == "Cancel")
+            return;
+
+        var action = AddAction(BabyNannyRepository.ActionTypes.Diaper);
+        if (action == null)
+            return;
+
+        action.DiaperType = option;
+        StopAction(action);
+
+        TxtDiaperProgress = "a few seconds ago";
+        LstActivityActions?.Add(action);
+        InvokeAsync(StateHasChanged);
     }
 
     private BabyAction? GetLastAction(BabyNannyRepository.ActionTypes type)

--- a/BabyNanny/Data/BabyNannyRepository.cs
+++ b/BabyNanny/Data/BabyNannyRepository.cs
@@ -25,16 +25,18 @@ namespace BabyNanny.Data
                 _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.BottleType)} TEXT");
             if (!columns.Contains(nameof(BabyAction.MealDescription)))
                 _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.MealDescription)} TEXT");
+            if (!columns.Contains(nameof(BabyAction.DiaperType)))
+                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.DiaperType)} TEXT");
         }
 
         #region Child
 
         public List<Child>? GetChildren()
         {
-            Init();      
+            Init();
             return _connection.GetAllWithChildren<Child>();
             //return _connection?.Table<Child>().ToList();
-            
+
         }
 
         public Child AddChild(Child child)
@@ -57,21 +59,21 @@ namespace BabyNanny.Data
         public List<BabyAction>? GetActions()
         {
             Init();
-            return _connection?.Table<BabyAction>().OrderByDescending(x=>x.Started).ToList();
+            return _connection?.Table<BabyAction>().OrderByDescending(x => x.Started).ToList();
         }
 
         public void AddAction(BabyAction? action)
         {
             _connection = new SQLiteConnection(dbPath);
             _connection.Insert(action);
-      
+
         }
 
         public void EditAction(BabyAction action)
         {
             _connection = new SQLiteConnection(dbPath);
             _connection.Update(action);
-      
+
         }
 
         public void DeleteAction(int id)

--- a/BabyNanny/Models/BabyAction.cs
+++ b/BabyNanny/Models/BabyAction.cs
@@ -30,6 +30,7 @@ namespace BabyNanny.Models
         public int? AmountML { get; set; }
         public string? BottleType { get; set; }
         public string? MealDescription { get; set; }
+        public string? DiaperType { get; set; }
 
         [ForeignKey(typeof(Child))]
         public int ChildId { get; set; }


### PR DESCRIPTION
## Summary
- store diaper type in the `BabyAction` table
- extend DB initialization to create new `DiaperType` column
- prompt for Pee/Poo/Both when logging a diaper change

## Testing
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj --no-build --logger "trx"`

------
https://chatgpt.com/codex/tasks/task_e_6852c06e638c83208a291ecf50727bd9