### PR TITLE
Fix tab icons on iOS

### DIFF
--- a/BabyNanny/MainPage.xaml
+++ b/BabyNanny/MainPage.xaml
@@ -5,7 +5,7 @@
     xmlns:pages="clr-namespace:BabyNanny.Components.Pages"
     x:Class="BabyNanny.MainPage">
 
-    <ContentPage Title="Home" IconImageSource="home.svg">
+    <ContentPage IconImageSource="home.svg">
         <BlazorWebView HostPage="wwwroot/index.html">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type pages:Home}" />
@@ -13,7 +13,7 @@
         </BlazorWebView>
     </ContentPage>
 
-    <ContentPage Title="Stats" IconImageSource="stats.svg">
+    <ContentPage IconImageSource="stats.svg">
         <BlazorWebView HostPage="wwwroot/index.html">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type pages:Stats}" />


### PR DESCRIPTION
## Summary
- update MainPage tabbed page items to only use icons

## Testing
- `dotnet test BabyNanny.sln` *(fails: logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_6852c337a980832084bdd9036f094360