### PR TITLE
Fix event attributes in razor pages

### DIFF
--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -22,7 +22,7 @@
             </h6>
 
         </div>
-        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" @onclick:stopPropagation="true" OnClick="@(async () => await ActionClick(BabyNannyRepository.ActionTypes.Sleeping))">
+        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" @onclick:stopPropagation="true" @onclick="async () => await ActionClick(BabyNannyRepository.ActionTypes.Sleeping)">
             @BtnSleepText
         </TelerikButton>
     </div>
@@ -57,7 +57,7 @@
                 @TxtFeedProgress
             </h6>
         </div>
-        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" @onclick:stopPropagation="true" OnClick="@(async () => await ActionClick(BabyNannyRepository.ActionTypes.Feeding))">
+        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" @onclick:stopPropagation="true" @onclick="async () => await ActionClick(BabyNannyRepository.ActionTypes.Feeding)">
             @BtnFeedText
         </TelerikButton>
     </div>
@@ -100,6 +100,7 @@
     {
         <TelerikWindow @bind-Visible="IsEditPopupVisible" Modal="true" Width="350px">
             <WindowTitle>Edit Action</WindowTitle>
+            <WindowContent>
             <div class="m-3">
                 <div class="mb-2">
                     <label>Start Time</label>
@@ -145,6 +146,7 @@
                     <TelerikButton OnClick="() => IsEditPopupVisible = false" Class="ml-2">Cancel</TelerikButton>
                 </div>
             </div>
+            </WindowContent>
         </TelerikWindow>
     }
 </div>

--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -2,13 +2,13 @@
 
 <h3>Stats</h3>
 <div class="k-form d-flex gap-2 mb-3">
-    <select @bind="SelectedActionType" @bind:after="UpdateStats" class="form-select">
+    <select @bind="SelectedActionType" class="form-select">
         @foreach (var at in Enum.GetValues<BabyNannyRepository.ActionTypes>())
         {
             <option value="@((int)at)">@at</option>
         }
     </select>
-    <select @bind="SelectedRange" @bind:after="UpdateStats" class="form-select">
+    <select @bind="SelectedRange" class="form-select">
         @foreach (var d in TimeRanges)
         {
             <option value="@d">@d days</option>
@@ -28,8 +28,27 @@
 }
 
 @code {
-    private BabyNannyRepository.ActionTypes SelectedActionType { get; set; } = BabyNannyRepository.ActionTypes.Feeding;
-    private int SelectedRange { get; set; } = 7;
+    private BabyNannyRepository.ActionTypes _selectedActionType = BabyNannyRepository.ActionTypes.Feeding;
+    private BabyNannyRepository.ActionTypes SelectedActionType
+    {
+        get => _selectedActionType;
+        set
+        {
+            _selectedActionType = value;
+            UpdateStats();
+        }
+    }
+
+    private int _selectedRange = 7;
+    private int SelectedRange
+    {
+        get => _selectedRange;
+        set
+        {
+            _selectedRange = value;
+            UpdateStats();
+        }
+    }
     private double AveragePerDay { get; set; }
     private List<int> TimeRanges { get; } = new() { 7, 14, 30 };
     private List<ChartItem> SubtypeChartData { get; set; } = new();


### PR DESCRIPTION
## Summary
- update Stats page to avoid duplicate `onchange`
- fix Home page button click handlers to use `@onclick` with `stopPropagation`
- wrap window body in `<WindowContent>` to satisfy Telerik component rules

## Testing
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6853c67dfeec8320850bddf8d2c2e261