### PR TITLE
Add dark mode with AppThemeBinding

### DIFF
--- a/BabyNanny/App.xaml
+++ b/BabyNanny/App.xaml
@@ -6,8 +6,15 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <Color x:Key="PageBackgroundColor">#512bdf</Color>
-            <Color x:Key="PrimaryTextColor">White</Color>
+            <Color x:Key="PageBackgroundColor">
+                <AppThemeBinding x:TypeArguments="Color" Light="#512bdf" Dark="#1c1c1c" />
+            </Color>
+            <Color x:Key="PrimaryTextColor">
+                <AppThemeBinding x:TypeArguments="Color" Light="White" Dark="#e0e0e0" />
+            </Color>
+            <Color x:Key="PrimaryButtonColor">
+                <AppThemeBinding x:TypeArguments="Color" Light="#2b0b98" Dark="#372176" />
+            </Color>
 
             <Style TargetType="Label">
                 <Setter Property="TextColor" Value="{DynamicResource PrimaryTextColor}" />
@@ -17,7 +24,7 @@
             <Style TargetType="Button">
                 <Setter Property="TextColor" Value="{DynamicResource PrimaryTextColor}" />
                 <Setter Property="FontFamily" Value="OpenSansRegular" />
-                <Setter Property="BackgroundColor" Value="#2b0b98" />
+                <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryButtonColor}" />
                 <Setter Property="Padding" Value="14,10" />
             </Style>
 

--- a/BabyNanny/MainPage.xaml
+++ b/BabyNanny/MainPage.xaml
@@ -3,9 +3,10 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:BabyNanny.Components.Pages"
-    x:Class="BabyNanny.MainPage">
+    x:Class="BabyNanny.MainPage"
+    BackgroundColor="{DynamicResource PageBackgroundColor}">
 
-    <ContentPage IconImageSource="home.png">
+    <ContentPage IconImageSource="home.png" BackgroundColor="{DynamicResource PageBackgroundColor}">
         <BlazorWebView HostPage="wwwroot/index.html">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type pages:Home}" />
@@ -13,7 +14,7 @@
         </BlazorWebView>
     </ContentPage>
 
-    <ContentPage IconImageSource="stats.png">
+    <ContentPage IconImageSource="stats.png" BackgroundColor="{DynamicResource PageBackgroundColor}">
         <BlazorWebView HostPage="wwwroot/index.html">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type pages:Stats}" />


### PR DESCRIPTION
## Summary
- support automatic light/dark theme using `AppThemeBinding`
- bind TabbedPage and ContentPage backgrounds to theme colors

## Testing
- `dotnet msbuild BabyNanny.sln -t:Restore -noconsolelogger`
- `dotnet format BabyNanny.sln --no-restore`
- `dotnet test BabyNanny.sln -noconsolelogger -nologo --verbosity quiet`

------
https://chatgpt.com/codex/tasks/task_e_6853d35c1c5c83208d60222596b845e1