### PR TITLE
Fix stats update when actions missing start times

### DIFF
--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -64,7 +64,9 @@
         if (actions == null)
             return;
         var from = DateTime.Today.AddDays(-SelectedRange + 1);
-        var filtered = actions.Where(a => a.Started >= from && a.Type == (int)SelectedActionType).ToList();
+        var filtered = actions
+            .Where(a => a.Started.HasValue && a.Started.Value >= from && a.Type == (int)SelectedActionType)
+            .ToList();
         AveragePerDay = filtered.Count / (double)SelectedRange;
 
         if (SelectedActionType == BabyNannyRepository.ActionTypes.Feeding)


### PR DESCRIPTION
## Summary
- avoid null DateTime comparisons when calculating stats

## Testing
- `dotnet restore BabyNanny.Tests/BabyNanny.Tests.csproj`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6854190b0e208320a460547c7b0582ba