### PR TITLE
Fix Stats page imports

### DIFF
--- a/BabyNanny/Components/_Imports.razor
+++ b/BabyNanny/Components/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing


### PR DESCRIPTION
## Summary
- fix typographical error in `_Imports.razor` that broke stats page

## Testing
- `dotnet build BabyNanny/BabyNanny.csproj -nologo` *(fails: workload maui-android missing)*

------
https://chatgpt.com/codex/tasks/task_e_68541ebf04d4832099caab59bb927b4f