### PR TITLE
Replace Telerik chart with Chart.js

### DIFF
--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -1,4 +1,5 @@
 @page "/stats"
+@inject IJSRuntime JSRuntime
 
 <h3>Stats</h3>
 <div class="k-form d-flex gap-2 mb-3">
@@ -18,13 +19,11 @@
 <p>Average per day: @AveragePerDay.ToString("0.##")</p>
 @if (SubtypeChartData?.Count > 0)
 {
-    <TelerikChart>
-        <ChartSeriesItems>
-            <ChartSeries Type="ChartSeriesType.Column" Name="Average" Data="@SubtypeChartData" Field="Value" CategoryField="Category">
-                <ChartSeriesLabels Visible="true"></ChartSeriesLabels>
-            </ChartSeries>
-        </ChartSeriesItems>
-    </TelerikChart>
+    <canvas id="statsChart" width="400" height="300"></canvas>
+}
+else
+{
+    <p>No data available.</p>
 }
 
 @code {
@@ -52,6 +51,7 @@
     private double AveragePerDay { get; set; }
     private List<int> TimeRanges { get; } = new() { 7, 14, 30 };
     private List<ChartItem> SubtypeChartData { get; set; } = new();
+    private bool _shouldRenderChart;
 
     protected override void OnInitialized()
     {
@@ -87,6 +87,25 @@
         {
             SubtypeChartData = new();
         }
+
+        _shouldRenderChart = true;
+        InvokeAsync(StateHasChanged);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_shouldRenderChart)
+        {
+            _shouldRenderChart = false;
+            await RenderChart();
+        }
+    }
+
+    private Task RenderChart()
+    {
+        var labels = SubtypeChartData.Select(c => c.Category).ToList();
+        var values = SubtypeChartData.Select(c => c.Value).ToList();
+        return JSRuntime.InvokeVoidAsync("renderStatsChart", labels, values).AsTask();
     }
 
     public class ChartItem

--- a/BabyNanny/wwwroot/index.html
+++ b/BabyNanny/wwwroot/index.html
@@ -13,6 +13,8 @@
 
     <link rel="stylesheet" href="_content/Telerik.UI.for.Blazor/css/kendo-theme-default/all.css" />
     <script src="_content/Telerik.UI.for.Blazor/js/telerik-blazor.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="js/StatsChart.js"></script>
 </head>
 
 <body>

--- a/BabyNanny/wwwroot/js/StatsChart.js
+++ b/BabyNanny/wwwroot/js/StatsChart.js
@@ -1,0 +1,28 @@
+window.statsChart = window.statsChart || null;
+
+window.renderStatsChart = (labels, values) => {
+    const ctx = document.getElementById('statsChart');
+    if (!ctx) return;
+    if (window.statsChart) {
+        window.statsChart.destroy();
+    }
+    window.statsChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Average',
+                data: values,
+                backgroundColor: 'rgba(54, 162, 235, 0.5)'
+            }]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: {
+                    beginAtZero: true
+                }
+            }
+        }
+    });
+};


### PR DESCRIPTION
## Summary
- show chart on stats page using Chart.js instead of Telerik
- include Chart.js resources and script

## Testing
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj -v diag`

------
https://chatgpt.com/codex/tasks/task_e_68545df21f5c83209b914e663ea98b3b