### PR TITLE
Improve stats layout and icon themes

### DIFF
--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -1,6 +1,7 @@
 @page "/stats"
 @inject IJSRuntime JSRuntime
 
+<div class="container my-3">
 <h3>Stats</h3>
 <div class="k-form d-flex gap-2 mb-3">
     <select @bind="SelectedActionType" class="form-select">
@@ -15,6 +16,7 @@
             <option value="@d">@d days</option>
         }
     </select>
+
 </div>
 <p>Average per day: @AveragePerDay.ToString("0.##")</p>
 @if (SubtypeChartData?.Count > 0)
@@ -25,6 +27,7 @@ else
 {
     <p>No data available.</p>
 }
+</div>
 
 @code {
     private BabyNannyRepository.ActionTypes _selectedActionType = BabyNannyRepository.ActionTypes.Feeding;

--- a/BabyNanny/MainPage.xaml
+++ b/BabyNanny/MainPage.xaml
@@ -6,7 +6,7 @@
     x:Class="BabyNanny.MainPage"
     BackgroundColor="{DynamicResource PageBackgroundColor}">
 
-    <ContentPage IconImageSource="home.png" BackgroundColor="{DynamicResource PageBackgroundColor}">
+    <ContentPage IconImageSource="{AppThemeBinding Light=home.png, Dark=home_white.png}" BackgroundColor="{DynamicResource PageBackgroundColor}">
         <BlazorWebView HostPage="wwwroot/index.html">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type pages:Home}" />
@@ -14,7 +14,7 @@
         </BlazorWebView>
     </ContentPage>
 
-    <ContentPage IconImageSource="stats.png" BackgroundColor="{DynamicResource PageBackgroundColor}">
+    <ContentPage IconImageSource="{AppThemeBinding Light=stats.png, Dark=stats_white.png}" BackgroundColor="{DynamicResource PageBackgroundColor}">
         <BlazorWebView HostPage="wwwroot/index.html">
             <BlazorWebView.RootComponents>
                 <RootComponent Selector="#app" ComponentType="{x:Type pages:Stats}" />

--- a/BabyNanny/Resources/Images/home_white.svg
+++ b/BabyNanny/Resources/Images/home_white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+  <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+</svg>

--- a/BabyNanny/Resources/Images/stats_white.svg
+++ b/BabyNanny/Resources/Images/stats_white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+  <path d="M5 9v10h3V9H5zm5.5-6v16h3V3h-3zm5.5 9v7h3v-7h-3z"/>
+</svg>


### PR DESCRIPTION
## Summary
- style stats page with padding container
- add dark and light icons for tab navigation
- switch tabs to use AppThemeBinding

## Testing
- `dotnet restore` *(fails: NETSDK1147 missing maui workloads)*
- `dotnet test BabyNanny.sln --no-restore` *(fails: NETSDK1147 missing maui workloads)*

------
https://chatgpt.com/codex/tasks/task_e_68546225702883209ae5f8e757ae85b4