### PR TITLE
Fix sleep stats

### DIFF
--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -22,7 +22,7 @@
             </h6>
 
         </div>
-        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" @onclick="async () => await ActionClick(BabyNannyRepository.ActionTypes.Sleeping)">
+        <TelerikButton Class="homeButton" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="@(ThemeConstants.Button.ThemeColor.Primary)" @onclick:stopPropagation="true" @onclick="async () => await ActionClick(BabyNannyRepository.ActionTypes.Sleeping)">
             @BtnSleepText
         </TelerikButton>
     </div>

--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -70,6 +70,20 @@ else
         var filtered = actions
             .Where(a => a.Started.HasValue && a.Started.Value >= from && a.Type == (int)SelectedActionType)
             .ToList();
+
+        if (SelectedActionType == BabyNannyRepository.ActionTypes.Sleeping)
+        {
+            var completed = filtered.Where(a => a.Stopped.HasValue).ToList();
+            AveragePerDay = completed.Sum(a => (a.Stopped!.Value - a.Started!.Value).TotalHours) / SelectedRange;
+            SubtypeChartData = new()
+            {
+                new ChartItem { Category = "Sleep", Value = AveragePerDay }
+            };
+            _shouldRenderChart = true;
+            InvokeAsync(StateHasChanged);
+            return;
+        }
+
         AveragePerDay = filtered.Count / (double)SelectedRange;
 
         if (SelectedActionType == BabyNannyRepository.ActionTypes.Feeding)


### PR DESCRIPTION
## Summary
- fix event bubbling for sleep button
- chart sleep hours on Stats page

## Testing
- `dotnet format BabyNanny.sln --no-restore --include BabyNanny/Components/Pages/Home.razor BabyNanny/Components/Pages/Stats.razor --verbosity diagnostic`
- `dotnet test BabyNanny.sln --no-build --verbosity minimal` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685469ae4d588320a8f0c2d68939c3b4