### PR TITLE
Fix edit popup crash

### DIFF
--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -356,6 +356,7 @@
             EditingMealDescription = action.MealDescription;
         }
         IsEditPopupVisible = true;
+        InvokeAsync(StateHasChanged);
     }
 
     private void SaveEdit()
@@ -409,6 +410,8 @@
 
     private void UpdateTime(object? source, ElapsedEventArgs e)
     {
+        if (_lastAction == null || _startTime == null)
+            return;
         var currentTime = DateTime.Now;
         var timeSpan = currentTime - _startTime;
         switch (_lastAction.Type)


### PR DESCRIPTION
## Summary
- ensure update timer handles missing state
- force UI refresh when showing edit popup

## Testing
- `dotnet format BabyNanny.Tests/BabyNanny.Tests.csproj --no-restore`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68547652ba988320ac617983bc113bfa