### PR TITLE
Enforce single active action

### DIFF
--- a/BabyNanny.Api/Program.cs
+++ b/BabyNanny.Api/Program.cs
@@ -34,6 +34,13 @@ app.MapPut("/api/children/{id}", async (int id, Child updated, BabyNannyContext 
 
 app.MapPost("/api/actions", async (BabyAction action, BabyNannyContext db) =>
 {
+    var exists = await db.Actions.AnyAsync(a =>
+        a.ChildId == action.ChildId && a.Started != null && a.Stopped == null);
+    if (exists)
+    {
+        return Results.BadRequest(new { message = "An action is already running for this child." });
+    }
+
     db.Actions.Add(action);
     await db.SaveChangesAsync();
     return Results.Created($"/api/actions/{action.Id}", action);

--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -179,7 +179,14 @@
             ChildId = LstChildren[0].Id,
             FeedingType = feedType
         };
-        App.BabyNannyRepository?.AddAction(action);
+        var added = App.BabyNannyRepository?.AddAction(action) ?? false;
+        if (!added)
+        {
+            await DialogService.DisplayAlert("Action Active",
+                "Another action is already running for this child.", "OK", "");
+            return;
+        }
+
         LstActions?.Add(action);
         LstActions = LstActions?.OrderByDescending(x => x.Started).ToList();
         _lastAction = action;
@@ -215,7 +222,7 @@
         if (string.IsNullOrEmpty(option) || option == "Cancel")
             return;
 
-        var action = AddAction(BabyNannyRepository.ActionTypes.Diaper);
+        var action = await AddAction(BabyNannyRepository.ActionTypes.Diaper);
         if (action == null)
             return;
 
@@ -244,7 +251,7 @@
             return;
         }
 
-        var action = AddAction(BabyNannyRepository.ActionTypes.Sleeping);
+        var action = await AddAction(BabyNannyRepository.ActionTypes.Sleeping);
         if (action == null)
             return;
 
@@ -269,11 +276,17 @@
         return action;
     }
 
-    private BabyAction? AddAction(BabyNannyRepository.ActionTypes type)
+    private async Task<BabyAction?> AddAction(BabyNannyRepository.ActionTypes type)
     {
         if (LstChildren == null) return null;
         var action = new BabyAction { Type = (int)type, Started = DateTime.Now, ChildId = LstChildren[0].Id };
-        App.BabyNannyRepository?.AddAction(action);
+        var added = App.BabyNannyRepository?.AddAction(action) ?? false;
+        if (!added)
+        {
+            await DialogService.DisplayAlert("Action Active",
+                "Another action is already running for this child.", "OK", "");
+            return null;
+        }
         LstActions?.Add(action);
         LstActions = LstActions?.OrderByDescending(x => x.Started).ToList();
         _lastAction = action;

--- a/BabyNanny/Data/BabyNannyRepository.cs
+++ b/BabyNanny/Data/BabyNannyRepository.cs
@@ -62,10 +62,21 @@ namespace BabyNanny.Data
             return _connection?.Table<BabyAction>().OrderByDescending(x => x.Started).ToList();
         }
 
-        public void AddAction(BabyAction? action)
+        public bool AddAction(BabyAction? action)
         {
+            if (action == null)
+                return false;
+
             _connection = new SQLiteConnection(dbPath);
+
+            var existing = _connection.Table<BabyAction>()
+                .FirstOrDefault(a => a.ChildId == action.ChildId && a.Started != null && a.Stopped == null);
+
+            if (existing != null)
+                return false;
+
             _connection.Insert(action);
+            return true;
 
         }
 

--- a/BabyNanny/Data/DialogService.cs
+++ b/BabyNanny/Data/DialogService.cs
@@ -1,18 +1,18 @@
 ﻿namespace BabyNanny.Data
 {
-    internal class DialogService: IDialogService
+    internal class DialogService : IDialogService
     {
-        public async Task<string> DisplayPrompt(string title,string message)
+        public async Task<string> DisplayPrompt(string title, string message)
         {
-            return await Application.Current!.Windows[0].Page!.DisplayPromptAsync(title,message);
+            return await Application.Current!.Windows[0].Page!.DisplayPromptAsync(title, message);
         }
 
-        public async Task<bool> DisplayAlert(string title,string message,string accept ,string cancel)
+        public async Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
         {
-            return await Application.Current!.Windows[0].Page!.DisplayAlert(title,message,accept,cancel);
+            return await Application.Current!.Windows[0].Page!.DisplayAlert(title, message, accept, cancel);
         }
 
-        public async Task<string?> DisplayActionSheet(string title,string cancel,string destruction, params string[] buttons)
+        public async Task<string?> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
         {
             return await Application.Current!.Windows[0].Page!.DisplayActionSheet(title, cancel, destruction, buttons);
         }

--- a/BabyNanny/Data/IDialogService.cs
+++ b/BabyNanny/Data/IDialogService.cs
@@ -2,7 +2,7 @@
 
 internal interface IDialogService
 {
-    Task<string> DisplayPrompt(string title,string message);
-    Task<bool> DisplayAlert(string title,string message,string accept ,string cancel);
-    Task<string?> DisplayActionSheet(string title,string cancel,string destruction, params string[] buttons);
+    Task<string> DisplayPrompt(string title, string message);
+    Task<bool> DisplayAlert(string title, string message, string accept, string cancel);
+    Task<string?> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons);
 }

--- a/BabyNanny/MauiProgram.cs
+++ b/BabyNanny/MauiProgram.cs
@@ -12,27 +12,27 @@ namespace BabyNanny
         public static MauiApp CreateMauiApp()
         {
             var builder = MauiApp.CreateBuilder();
-            builder                
+            builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 });
 
-            builder.Services.AddMauiBlazorWebView();           
+            builder.Services.AddMauiBlazorWebView();
             builder.Services.AddTelerikBlazor();
-            builder.Services.AddSingleton(c=>Connectivity.Current);
-            builder.Services.AddSingleton<IDialogService,DialogService>();
+            builder.Services.AddSingleton(c => Connectivity.Current);
+            builder.Services.AddSingleton<IDialogService, DialogService>();
 #if DEBUG
-    		builder.Services.AddBlazorWebViewDeveloperTools();
-    		builder.Logging.AddDebug();
+            builder.Services.AddBlazorWebViewDeveloperTools();
+            builder.Logging.AddDebug();
 #endif
 
 
-            var dbPath = Path.Combine(FileSystem.AppDataDirectory,"BabyNanny.db");
+            var dbPath = Path.Combine(FileSystem.AppDataDirectory, "BabyNanny.db");
 
-            builder.Services.AddSingleton(s=> ActivatorUtilities.CreateInstance<BabyNannyRepository>(s,dbPath));
-            
+            builder.Services.AddSingleton(s => ActivatorUtilities.CreateInstance<BabyNannyRepository>(s, dbPath));
+
 
 
             return builder.Build();

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ BabyNanny.sln
 
 * **MauiProgram.cs** configures the app, registers services and sets up the SQLite-backed `BabyNannyRepository`.
 * **BabyNannyRepository** creates tables for `Child` and `BabyAction` and exposes CRUD methods.
+* Starting a new action checks for an existing one in progress to avoid overlap.
 * **Models** (`Child` and `BabyAction`) map to SQLite tables using attributes from `sqlite-net` and `SQLiteNetExtensions`.
 * **Home.razor** implements the main UI where users log feeding, sleeping and diaper events.
 


### PR DESCRIPTION
## Summary
- block inserting a new action when one is already active via API
- check for existing active actions before inserting into the SQLite repository
- surface an alert when the user tries to start overlapping actions
- document the behavior in the README

## Testing
- `dotnet format --no-restore`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_6854fc316b2c8320bebd1f637030b861