### PR TITLE
Add multi-child tracking

### DIFF
--- a/BabyNanny.Tests/BabyNanny.Tests.csproj
+++ b/BabyNanny.Tests/BabyNanny.Tests.csproj
@@ -2,14 +2,20 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageReference Include="SQLiteNetExtensions" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Include the TimeUtils helper directly so MAUI workloads are not required -->
     <Compile Include="..\BabyNanny\Helpers\TimeUtils.cs" Link="TimeUtils.cs" />
+    <Compile Include="..\BabyNanny\Data\BabyNannyRepository.cs" Link="BabyNannyRepository.cs" />
+    <Compile Include="..\BabyNanny\Models\Child.cs" Link="Child.cs" />
+    <Compile Include="..\BabyNanny\Models\BabyAction.cs" Link="BabyAction.cs" />
   </ItemGroup>
 </Project>

--- a/BabyNanny.Tests/RepositoryTests.cs
+++ b/BabyNanny.Tests/RepositoryTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using BabyNanny.Data;
+using BabyNanny.Models;
+using Xunit;
+
+namespace BabyNanny.Tests
+{
+    public class RepositoryTests
+    {
+        [Fact]
+        public void GetActions_FiltersByChild()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                var repo = new BabyNannyRepository(path);
+                repo.Init();
+                var c1 = repo.AddChild(new Child { Name = "A" });
+                var c2 = repo.AddChild(new Child { Name = "B" });
+                repo.AddAction(new BabyAction { Type = 0, Started = DateTime.Now, ChildId = c1.Id });
+                repo.AddAction(new BabyAction { Type = 0, Started = DateTime.Now, ChildId = c2.Id });
+
+                var filtered = repo.GetActions(c1.Id);
+                Assert.All(filtered, a => Assert.Equal(c1.Id, a.ChildId));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/BabyNanny/Components/Layout/NavMenu.razor
+++ b/BabyNanny/Components/Layout/NavMenu.razor
@@ -1,7 +1,6 @@
 <div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid d-flex align-items-center gap-2">
+    <div class="container-fluid">
         <a class="navbar-brand" href="">Baby Nanny</a>
-        <ChildSelector />
     </div>
 </div>
 

--- a/BabyNanny/Components/Layout/NavMenu.razor
+++ b/BabyNanny/Components/Layout/NavMenu.razor
@@ -1,7 +1,10 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">Baby Nanny</a>
     </div>
+</div>
+<div class="p-2">
+    <ChildSelector />
 </div>
 
 <input type="checkbox" title="Navigation menu" class="navbar-toggler" />

--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -6,6 +6,7 @@
 @inject IConnectivity ConnectivityService;
 @inject NavigationManager NavigationManager;
 @inject IDialogService DialogService;
+@inject ChildStateService ChildState;
 
 
 <div>
@@ -176,7 +177,7 @@
         {
             Type = (int)BabyNannyRepository.ActionTypes.Feeding,
             Started = DateTime.Now,
-            ChildId = LstChildren[0].Id,
+            ChildId = ChildState.SelectedChildId,
             FeedingType = feedType
         };
         var added = App.BabyNannyRepository?.AddAction(action) ?? false;
@@ -264,7 +265,7 @@
 
     private BabyAction? GetLastAction(BabyNannyRepository.ActionTypes type)
     {
-        LstActions ??= App.BabyNannyRepository?.GetActions();
+        LstActions ??= App.BabyNannyRepository?.GetActions(ChildState.SelectedChildId);
         var babyAction = LstActions?.OrderByDescending(s => s.Started).FirstOrDefault(s => s.Type == (int)type);
         return babyAction;
     }
@@ -278,8 +279,14 @@
 
     private async Task<BabyAction?> AddAction(BabyNannyRepository.ActionTypes type)
     {
-        if (LstChildren == null) return null;
-        var action = new BabyAction { Type = (int)type, Started = DateTime.Now, ChildId = LstChildren[0].Id };
+        if (LstChildren == null)
+            return null;
+        var action = new BabyAction
+        {
+            Type = (int)type,
+            Started = DateTime.Now,
+            ChildId = ChildState.SelectedChildId
+        };
         var added = App.BabyNannyRepository?.AddAction(action) ?? false;
         if (!added)
         {
@@ -344,28 +351,37 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        var lstChildren = App.BabyNannyRepository?.GetChildren();
-        var lstActions = App.BabyNannyRepository?.GetActions();
+        ChildState.ChildChanged += HandleChildChanged;
+        var children = App.BabyNannyRepository?.GetChildren() ?? new List<Child>();
+        if (!children.Any())
+        {
+            var child = App.BabyNannyRepository?.AddChild(new Child { Name = "Child 1" });
+            if (child != null)
+                children.Add(child);
+        }
+
+        LstChildren = children;
+
+        if (ChildState.SelectedChildId == 0 && children.Any())
+            ChildState.SetChild(children[0].Id);
+
+        LstActivityActions = new List<BabyAction>();
+        LoadChildActions();
+    }
+
+    private void HandleChildChanged()
+    {
+        LoadChildActions();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void LoadChildActions()
+    {
+        var lstActions = App.BabyNannyRepository?.GetActions(ChildState.SelectedChildId);
         _currentTime = DateTime.Now;
 
         if (lstActions is { Count: > 0 })
             _lastAction = lstActions[0];
-
-        LstActivityActions = new List<BabyAction>();
-        if (lstChildren != null && lstChildren.Any())
-            LstChildren = lstChildren;
-        else
-        {
-            LstChildren = new List<Child>();
-            // var childName = DialogService.DisplayPrompt("Add Child", "Please enter the child's name").Result;
-            var childName = "Child 1";
-            if (!string.IsNullOrEmpty(childName))
-            {
-                var child = App.BabyNannyRepository?.AddChild(new Child { Name = childName });
-                if (child != null)
-                    LstChildren.Add(child);
-            }
-        }
 
         if (lstActions != null && lstActions.Any())
         {
@@ -374,7 +390,6 @@
             var sleepAction = GetLastAction(BabyNannyRepository.ActionTypes.Sleeping);
             if (sleepAction?.Stopped == null)
             {
-
                 TxtSleepProgress = "In Progress";
                 TxtSleep = (DateTime.Now - sleepAction?.Started).GetValueOrDefault().ToString(@"hh\:mm\:ss");
                 BtnSleepText = "Stop";
@@ -387,7 +402,6 @@
             var feedAction = GetLastAction(BabyNannyRepository.ActionTypes.Feeding);
             if (feedAction?.Stopped == null)
             {
-
                 TxtFeedProgress = "In Progress";
                 TxtFeed = (DateTime.Now - feedAction?.Started).GetValueOrDefault().ToString(@"hh\:mm\:ss");
                 BtnFeedText = "Stop";
@@ -405,12 +419,12 @@
 
             RefreshActivityActions();
 
-            // Resume timer for any ongoing action after app restart
             var runningActions = new[] { sleepAction, feedAction }
                 .Where(a => a?.Stopped == null)
                 .OrderByDescending(a => a?.Started)
                 .ToList();
 
+            StopTimer();
             if (runningActions.Any())
             {
                 var resumeAction = runningActions.First();
@@ -421,6 +435,11 @@
         else
         {
             LstActions = new List<BabyAction>();
+            TxtSleepProgress = string.Empty;
+            TxtFeedProgress = string.Empty;
+            TxtDiaperProgress = string.Empty;
+            BtnSleepText = "Start";
+            BtnFeedText = "Start";
         }
     }
 

--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -8,6 +8,9 @@
 @inject IDialogService DialogService;
 @inject ChildStateService ChildState;
 
+<div class="d-flex justify-content-end p-2">
+    <ChildSelector />
+</div>
 
 <div>
     <div class="item">

--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -2,6 +2,10 @@
 @inject IJSRuntime JSRuntime
 @inject ChildStateService ChildState
 
+<div class="d-flex justify-content-end p-2">
+    <ChildSelector />
+</div>
+
 <div class="container my-3">
 <h3>Stats</h3>
 <div class="k-form d-flex gap-2 mb-3">

--- a/BabyNanny/Components/Pages/Stats.razor
+++ b/BabyNanny/Components/Pages/Stats.razor
@@ -1,5 +1,6 @@
 @page "/stats"
 @inject IJSRuntime JSRuntime
+@inject ChildStateService ChildState
 
 <div class="container my-3">
 <h3>Stats</h3>
@@ -58,12 +59,19 @@ else
 
     protected override void OnInitialized()
     {
+        ChildState.ChildChanged += HandleChildChanged;
         UpdateStats();
+    }
+
+    private void HandleChildChanged()
+    {
+        UpdateStats();
+        InvokeAsync(StateHasChanged);
     }
 
     private void UpdateStats()
     {
-        var actions = App.BabyNannyRepository?.GetActions();
+        var actions = App.BabyNannyRepository?.GetActions(ChildState.SelectedChildId);
         if (actions == null)
             return;
         var from = DateTime.Today.AddDays(-SelectedRange + 1);
@@ -129,5 +137,10 @@ else
     {
         public string Category { get; set; } = string.Empty;
         public double Value { get; set; }
+    }
+
+    public void Dispose()
+    {
+        ChildState.ChildChanged -= HandleChildChanged;
     }
 }

--- a/BabyNanny/Components/Shared/ChildSelector.razor
+++ b/BabyNanny/Components/Shared/ChildSelector.razor
@@ -1,6 +1,5 @@
-@using BabyNanny.Models
-@inject ChildStateService ChildState
-@inject IDialogService DialogService
+<div class="child-selector d-flex align-items-center gap-2">
+    <select class="form-select form-select-sm w-auto" @onchange="OnChange" value="@_selectedId">
 
 <input id="childMenuToggle" type="checkbox" title="Child menu" class="child-menu-toggle" />
 <div class="child-menu" onclick="document.getElementById('childMenuToggle').checked = false;">

--- a/BabyNanny/Components/Shared/ChildSelector.razor
+++ b/BabyNanny/Components/Shared/ChildSelector.razor
@@ -1,3 +1,4 @@
+@using BabyNanny.Models
 @inject ChildStateService ChildState
 @inject IDialogService DialogService
 

--- a/BabyNanny/Components/Shared/ChildSelector.razor
+++ b/BabyNanny/Components/Shared/ChildSelector.razor
@@ -1,0 +1,56 @@
+@inject ChildStateService ChildState
+@inject IDialogService DialogService
+
+<select class="form-select form-select-sm w-auto d-inline" @onchange="OnChange" value="@_selectedId">
+    @foreach (var c in Children)
+    {
+        <option value="@c.Id">@c.Name</option>
+    }
+</select>
+<TelerikButton Class="ms-2" Size="@(ThemeConstants.Button.Size.Small)" OnClick="AddChild">Add Child</TelerikButton>
+
+@code {
+    private List<Child> Children { get; set; } = new();
+    private int _selectedId;
+
+    protected override void OnInitialized()
+    {
+        Children = App.BabyNannyRepository?.GetChildren() ?? new();
+        if (Children.Count > 0)
+        {
+            _selectedId = ChildState.SelectedChildId;
+            if (_selectedId == 0)
+            {
+                _selectedId = Children[0].Id;
+                ChildState.SetChild(_selectedId);
+            }
+        }
+    }
+
+    private void OnChange(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var id))
+        {
+            _selectedId = id;
+            ChildState.SetChild(id);
+        }
+    }
+
+    private async Task AddChild()
+    {
+        var name = await DialogService.DisplayPrompt("Child Name", "Enter child's name");
+        if (string.IsNullOrWhiteSpace(name))
+            return;
+        var birthdayStr = await DialogService.DisplayPrompt("Birthday", "yyyy-MM-dd (optional)");
+        DateTime? birthday = null;
+        if (DateTime.TryParse(birthdayStr, out var bday))
+            birthday = bday;
+        var child = App.BabyNannyRepository?.AddChild(new Child { Name = name, Birthday = birthday });
+        if (child != null)
+        {
+            Children.Add(child);
+            _selectedId = child.Id;
+            ChildState.SetChild(child.Id);
+        }
+    }
+}

--- a/BabyNanny/Components/Shared/ChildSelector.razor.css
+++ b/BabyNanny/Components/Shared/ChildSelector.razor.css
@@ -1,23 +1,3 @@
-.child-menu-toggle {
-    appearance: none;
-    cursor: pointer;
-    width: 2.5rem;
-    height: 2.5rem;
-    border: 1px solid rgba(0,0,0,0.1);
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%280,0,0,0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.5rem rgba(0,0,0,0.05);
-}
-
-.child-menu {
-    display: none;
-    position: absolute;
-    margin-top: 0.5rem;
-    padding: 0.5rem;
-    background-color: white;
-    border: 1px solid rgba(0,0,0,0.2);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    z-index: 1000;
-}
-
-.child-menu-toggle:checked ~ .child-menu {
-    display: block;
+.child-selector {
+    margin-bottom: 0.5rem;
 }

--- a/BabyNanny/Components/_Imports.razor
+++ b/BabyNanny/Components/_Imports.razor
@@ -7,6 +7,7 @@
 @using Microsoft.JSInterop
 @using BabyNanny
 @using BabyNanny.Components
+@using BabyNanny.Components.Shared
 @using BabyNanny.Data
 @using BabyNanny.Components.Pages
 @using Telerik.Blazor

--- a/BabyNanny/Data/BabyNannyRepository.cs
+++ b/BabyNanny/Data/BabyNannyRepository.cs
@@ -56,10 +56,13 @@ namespace BabyNanny.Data
 
         #region Action
 
-        public List<BabyAction>? GetActions()
+        public List<BabyAction>? GetActions(int? childId = null)
         {
             Init();
-            return _connection?.Table<BabyAction>().OrderByDescending(x => x.Started).ToList();
+            var query = _connection!.Table<BabyAction>().OrderByDescending(x => x.Started);
+            if (childId.HasValue && childId.Value > 0)
+                query = query.Where(a => a.ChildId == childId.Value);
+            return query.ToList();
         }
 
         public bool AddAction(BabyAction? action)

--- a/BabyNanny/Data/ChildStateService.cs
+++ b/BabyNanny/Data/ChildStateService.cs
@@ -1,0 +1,26 @@
+using Microsoft.Maui.Storage;
+using System;
+
+namespace BabyNanny.Data
+{
+    public class ChildStateService
+    {
+        private const string PreferenceKey = "SelectedChildId";
+
+        public event Action? ChildChanged;
+
+        public int SelectedChildId { get; private set; }
+
+        public ChildStateService()
+        {
+            SelectedChildId = Preferences.Default.Get(PreferenceKey, 0);
+        }
+
+        public void SetChild(int id)
+        {
+            SelectedChildId = id;
+            Preferences.Default.Set(PreferenceKey, id);
+            ChildChanged?.Invoke();
+        }
+    }
+}

--- a/BabyNanny/MauiProgram.cs
+++ b/BabyNanny/MauiProgram.cs
@@ -23,6 +23,7 @@ namespace BabyNanny
             builder.Services.AddTelerikBlazor();
             builder.Services.AddSingleton(c => Connectivity.Current);
             builder.Services.AddSingleton<IDialogService, DialogService>();
+            builder.Services.AddSingleton<ChildStateService>();
 #if DEBUG
             builder.Services.AddBlazorWebViewDeveloperTools();
             builder.Logging.AddDebug();

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ BabyNanny.sln
 * Starting a new action checks for an existing one in progress to avoid overlap.
 * **Models** (`Child` and `BabyAction`) map to SQLite tables using attributes from `sqlite-net` and `SQLiteNetExtensions`.
 * **Home.razor** implements the main UI where users log feeding, sleeping and diaper events.
-* A hamburger menu on each page lets you switch or add child profiles.
+* A child selector at the top of each page lets you switch or add profiles.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ BabyNanny.sln
 * Starting a new action checks for an existing one in progress to avoid overlap.
 * **Models** (`Child` and `BabyAction`) map to SQLite tables using attributes from `sqlite-net` and `SQLiteNetExtensions`.
 * **Home.razor** implements the main UI where users log feeding, sleeping and diaper events.
+* A hamburger menu on each page lets you switch or add child profiles.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- add `ChildStateService` to persist active child selection
- show `ChildSelector` component in `NavMenu`
- filter actions by child and reload pages on change
- adjust repository API for per-child queries
- add unit test for filtering

## Testing
- `dotnet restore BabyNanny.Tests/BabyNanny.Tests.csproj`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj`
- `dotnet format BabyNanny.Tests/BabyNanny.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6854fe9ed988832099471e7ec6fe8e9e