### PR TITLE
Fix DisplayAlert usage

### DIFF
--- a/BabyNanny/Components/Pages/Home.razor
+++ b/BabyNanny/Components/Pages/Home.razor
@@ -183,7 +183,7 @@
         if (!added)
         {
             await DialogService.DisplayAlert("Action Active",
-                "Another action is already running for this child.", "OK", "");
+                "Another action is already running for this child.", "OK");
             return;
         }
 
@@ -284,7 +284,7 @@
         if (!added)
         {
             await DialogService.DisplayAlert("Action Active",
-                "Another action is already running for this child.", "OK", "");
+                "Another action is already running for this child.", "OK");
             return null;
         }
         LstActions?.Add(action);

--- a/BabyNanny/Data/DialogService.cs
+++ b/BabyNanny/Data/DialogService.cs
@@ -7,6 +7,11 @@
             return await Application.Current!.Windows[0].Page!.DisplayPromptAsync(title, message);
         }
 
+        public async Task DisplayAlert(string title, string message, string cancel)
+        {
+            await Application.Current!.Windows[0].Page!.DisplayAlert(title, message, cancel);
+        }
+
         public async Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
         {
             return await Application.Current!.Windows[0].Page!.DisplayAlert(title, message, accept, cancel);

--- a/BabyNanny/Data/IDialogService.cs
+++ b/BabyNanny/Data/IDialogService.cs
@@ -3,6 +3,7 @@
 internal interface IDialogService
 {
     Task<string> DisplayPrompt(string title, string message);
+    Task DisplayAlert(string title, string message, string cancel);
     Task<bool> DisplayAlert(string title, string message, string accept, string cancel);
     Task<string?> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons);
 }


### PR DESCRIPTION
## Summary
- overload `DialogService.DisplayAlert` to allow single-button alerts
- update `IDialogService` interface
- use new overload in `Home.razor`

## Testing
- `dotnet format BabyNanny.sln --no-restore` *(fails: Required references did not load)*
- `dotnet test BabyNanny.sln --no-restore` *(fails: workload packs missing)*

------
https://chatgpt.com/codex/tasks/task_e_68551074e7bc8320b52dcbd000644bba