### PR TITLE
Fix TimeUtils seconds display bug

### DIFF
--- a/BabyNanny.Tests/TimeDifferenceTests.cs
+++ b/BabyNanny.Tests/TimeDifferenceTests.cs
@@ -71,5 +71,14 @@ namespace BabyNanny.Tests
             var result = TimeUtils.TimeDifference(start, end);
             Assert.Equal("1M 3d", result);
         }
+
+        [Fact]
+        public void GetTimeAgo_ReturnsSecondsWithAgoSuffix()
+        {
+            var past = new DateTime(2024, 1, 1, 0, 0, 0);
+            var now = past.AddSeconds(45);
+            var result = TimeUtils.GetTimeAgo(past, now);
+            Assert.Equal("45s ago", result);
+        }
     }
 }

--- a/BabyNanny/Helpers/TimeUtils.cs
+++ b/BabyNanny/Helpers/TimeUtils.cs
@@ -22,7 +22,7 @@ namespace BabyNanny.Helpers
             var days = timeSpan.Days % 30; // Approximate 30 days per month
             var hours = timeSpan.Hours;
             var minutes = timeSpan.Minutes;
-            var seconds = timeSpan.Seconds;
+            var seconds = (int)Math.Floor(timeSpan.TotalSeconds);
 
             var result = new List<string>();
 
@@ -42,12 +42,29 @@ namespace BabyNanny.Helpers
                     if (minutes > 0)
                         result.Add($"{minutes}m");
 
-                    if (timeSpan.TotalMinutes < 1 && seconds > 0)
+                    if (timeSpan.TotalMinutes < 1)
                         result.Add($"{seconds}s");
                 }
             }
 
             return string.Join(" ", result);
+        }
+
+        public static string GetTimeAgo(DateTime? past, DateTime? now = null)
+        {
+            if (past == null)
+                return "Invalid start time";
+
+            now ??= DateTime.Now;
+
+            var diff = TimeDifference(past, now);
+            if (string.IsNullOrEmpty(diff))
+            {
+                if ((now.Value - past.Value).TotalSeconds < 1)
+                    diff = "0s";
+            }
+
+            return $"{diff} ago";
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `TimeUtils.TimeDifference` always reports seconds even for sub-minute durations
- add `GetTimeAgo` helper
- verify via updated unit tests

## Testing
- `dotnet format --no-restore`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6855201f050c8320aabcea67643fdef2