### PR TITLE
Add child management in settings

### DIFF
--- a/BabyNanny.Tests/ChildRepositoryTests.cs
+++ b/BabyNanny.Tests/ChildRepositoryTests.cs
@@ -27,4 +27,15 @@ public class ChildRepositoryTests
         var list = repo.GetChildren();
         Assert.Equal("New", list!.First().Name);
     }
+
+    [Fact]
+    public void DeleteChild_RemovesChild()
+    {
+        var repo = new BabyNannyRepository(Path.GetTempFileName());
+        repo.Init();
+        var child = repo.AddChild(new Child { Name = "Test" });
+        repo.DeleteChild(child.Id);
+        var list = repo.GetChildren();
+        Assert.Empty(list!);
+    }
 }

--- a/BabyNanny/AppShell.xaml.cs
+++ b/BabyNanny/AppShell.xaml.cs
@@ -14,5 +14,6 @@ public partial class AppShell : Shell
     private async void OnSettingsClicked(object? sender, EventArgs e)
     {
         await GoToAsync("settings");
+        FlyoutIsPresented = false;
     }
 }

--- a/BabyNanny/Components/Pages/Settings.razor
+++ b/BabyNanny/Components/Pages/Settings.razor
@@ -1,14 +1,19 @@
 @page "/settings"
 @using BabyNanny.Models
+@using BabyNanny.Data
 @inject BabyNannyRepository Repository
 @inject ChildState ChildState
+@inject IDialogService DialogService
 
 <h3 class="mb-3">Children</h3>
-<TelerikListView Data="@ChildState.Children" Class="mb-4">
+<TelerikListView Data="@ChildState.Children" Class="mb-3">
     <Template>
-        <div class="d-flex justify-content-between align-items-center">
+        <div class="d-flex justify-content-between align-items-center border rounded p-2 mb-1">
             <span>@context.Name (@context.Birthday?.ToString("d"))</span>
-            <TelerikButton OnClick="() => EditChild(context)" Size="@(ThemeConstants.Button.Size.Small)">Edit</TelerikButton>
+            <span>
+                <TelerikButton OnClick="() => EditChild(context)" Size="@(ThemeConstants.Button.Size.Small)" Class="me-2">Edit</TelerikButton>
+                <TelerikButton OnClick="() => DeleteChildAsync(context)" Size="@(ThemeConstants.Button.Size.Small)" ThemeColor="ThemeColor.Error">Delete</TelerikButton>
+            </span>
         </div>
     </Template>
 </TelerikListView>
@@ -84,5 +89,15 @@ else
     {
         EditingChild = new Child();
         IsEditing = false;
+    }
+
+    private async Task DeleteChildAsync(Child child)
+    {
+        var confirm = await DialogService.DisplayAlert("Delete Child", $"Delete {child.Name}?", "Delete", "Cancel");
+        if (!confirm)
+            return;
+
+        Repository.DeleteChild(child.Id);
+        ChildState.RemoveChild(child.Id);
     }
 }

--- a/BabyNanny/Data/BabyNannyRepository.cs
+++ b/BabyNanny/Data/BabyNannyRepository.cs
@@ -7,55 +7,59 @@ namespace BabyNanny.Data
 {
     public class BabyNannyRepository(string dbPath)
     {
-        private SQLiteConnection? _connection;
+        private readonly string _dbPath = dbPath;
 
         public void Init()
         {
-            _connection = new SQLiteConnection(dbPath);
-            _connection.CreateTable<Child>();
-            _connection.CreateTable<BabyAction>();
+            using var _ = GetConnection();
+        }
 
-            var tableInfo = _connection.GetTableInfo(nameof(BabyAction));
+        private SQLiteConnection GetConnection()
+        {
+            var connection = new SQLiteConnection(_dbPath);
+            connection.CreateTable<Child>();
+            connection.CreateTable<BabyAction>();
+
+            var tableInfo = connection.GetTableInfo(nameof(BabyAction));
             var columns = tableInfo.Select(c => c.Name).ToList();
             if (!columns.Contains(nameof(BabyAction.FeedingType)))
-                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.FeedingType)} INTEGER");
+                connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.FeedingType)} INTEGER");
             if (!columns.Contains(nameof(BabyAction.AmountML)))
-                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.AmountML)} INTEGER");
+                connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.AmountML)} INTEGER");
             if (!columns.Contains(nameof(BabyAction.BottleType)))
-                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.BottleType)} TEXT");
+                connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.BottleType)} TEXT");
             if (!columns.Contains(nameof(BabyAction.MealDescription)))
-                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.MealDescription)} TEXT");
+                connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.MealDescription)} TEXT");
             if (!columns.Contains(nameof(BabyAction.DiaperType)))
-                _connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.DiaperType)} TEXT");
+                connection.Execute($"ALTER TABLE {nameof(BabyAction)} ADD COLUMN {nameof(BabyAction.DiaperType)} TEXT");
+            return connection;
         }
 
         #region Child
 
         public List<Child>? GetChildren()
         {
-            Init();
-            return _connection.GetAllWithChildren<Child>();
-            //return _connection?.Table<Child>().ToList();
-
+            using var db = GetConnection();
+            return db.GetAllWithChildren<Child>();
         }
 
         public Child AddChild(Child child)
         {
-            _connection = new SQLiteConnection(dbPath);
-            _connection.Insert(child);
+            using var db = GetConnection();
+            db.Insert(child);
             return child;
         }
 
         public void UpdateChild(Child child)
         {
-            _connection = new SQLiteConnection(dbPath);
-            _connection.Update(child);
+            using var db = GetConnection();
+            db.Update(child);
         }
 
         public void DeleteChild(int id)
         {
-            _connection = new SQLiteConnection(dbPath);
-            _connection.Delete<Child>(id);
+            using var db = GetConnection();
+            db.Delete<Child>(id);
         }
 
         #endregion
@@ -64,8 +68,8 @@ namespace BabyNanny.Data
 
         public List<BabyAction>? GetActions()
         {
-            Init();
-            return _connection?.Table<BabyAction>().OrderByDescending(x => x.Started).ToList();
+            using var db = GetConnection();
+            return db.Table<BabyAction>().OrderByDescending(x => x.Started).ToList();
         }
 
         public bool AddAction(BabyAction? action)
@@ -73,30 +77,30 @@ namespace BabyNanny.Data
             if (action == null)
                 return false;
 
-            _connection = new SQLiteConnection(dbPath);
+            using var db = GetConnection();
 
-            var existing = _connection.Table<BabyAction>()
+            var existing = db.Table<BabyAction>()
                 .FirstOrDefault(a => a.ChildId == action.ChildId && a.Started != null && a.Stopped == null);
 
             if (existing != null)
                 return false;
 
-            _connection.Insert(action);
+            db.Insert(action);
             return true;
 
         }
 
         public void EditAction(BabyAction action)
         {
-            _connection = new SQLiteConnection(dbPath);
-            _connection.Update(action);
+            using var db = GetConnection();
+            db.Update(action);
 
         }
 
         public void DeleteAction(int id)
         {
-            _connection = new SQLiteConnection(dbPath);
-            _connection.Delete<BabyAction>(id);
+            using var db = GetConnection();
+            db.Delete<BabyAction>(id);
         }
 
         #endregion

--- a/BabyNanny/Data/ChildState.cs
+++ b/BabyNanny/Data/ChildState.cs
@@ -57,4 +57,17 @@ public class ChildState : INotifyPropertyChanged
 
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Children)));
     }
+
+    public void RemoveChild(int id)
+    {
+        var child = _children.FirstOrDefault(c => c.Id == id);
+        if (child == null)
+            return;
+
+        _children.Remove(child);
+        if (_selectedChild?.Id == id)
+            SelectedChild = null;
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Children)));
+    }
 }

--- a/BabyNanny/Views/SettingsPage.xaml
+++ b/BabyNanny/Views/SettingsPage.xaml
@@ -4,7 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:BabyNanny.Components.Pages"
     x:Class="BabyNanny.Views.SettingsPage"
-    BackgroundColor="{DynamicResource PageBackgroundColor}">
+    BackgroundColor="{DynamicResource PageBackgroundColor}"
+    Padding="20">
     <BlazorWebView HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>
             <RootComponent Selector="#app" ComponentType="{x:Type pages:Settings}" />


### PR DESCRIPTION
## Summary
- style Settings page list and editing form
- add delete button with confirm dialog
- close flyout menu after navigating to Settings
- store child changes using sqlite repository
- cover DeleteChild with a test

## Testing
- `dotnet restore BabyNanny.Tests/BabyNanny.Tests.csproj`
- `dotnet format --no-restore BabyNanny/BabyNanny.csproj`
- `dotnet format --no-restore BabyNanny.Tests/BabyNanny.Tests.csproj`
- `dotnet test BabyNanny.Tests/BabyNanny.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68552c56af9083209d916ca1e5439c08