### PR TITLE
Add child management settings page

### DIFF
--- a/BabyNanny.Tests/ChildRepositoryTests.cs
+++ b/BabyNanny.Tests/ChildRepositoryTests.cs
@@ -38,4 +38,16 @@ public class ChildRepositoryTests
         var list = repo.GetChildren();
         Assert.Empty(list!);
     }
+
+    [Fact]
+    public void GetChildren_ReturnsAll()
+    {
+        var path = Path.GetTempFileName();
+        var repo = new BabyNannyRepository(path);
+        repo.Init();
+        repo.AddChild(new Child { Name = "A" });
+        repo.AddChild(new Child { Name = "B" });
+        var list = repo.GetChildren();
+        Assert.Equal(2, list!.Count);
+    }
 }

--- a/BabyNanny/AppShell.xaml.cs
+++ b/BabyNanny/AppShell.xaml.cs
@@ -9,6 +9,7 @@ public partial class AppShell : Shell
         InitializeComponent();
         BindingContext = childState;
         Routing.RegisterRoute("settings", typeof(Views.SettingsPage));
+        Routing.RegisterRoute("addchild", typeof(Views.AddChildPage));
     }
 
     private async void OnSettingsClicked(object? sender, EventArgs e)

--- a/BabyNanny/Views/AddChildPage.xaml
+++ b/BabyNanny/Views/AddChildPage.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="BabyNanny.Views.AddChildPage"
+    Title="Child">
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <Entry x:Name="nameEntry" Placeholder="Name" />
+        <DatePicker x:Name="birthdayPicker" />
+        <HorizontalStackLayout Spacing="10">
+            <Button Text="Save" Clicked="OnSaveClicked" />
+            <Button Text="Cancel" Clicked="OnCancelClicked" />
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
+</ContentPage>

--- a/BabyNanny/Views/AddChildPage.xaml.cs
+++ b/BabyNanny/Views/AddChildPage.xaml.cs
@@ -1,0 +1,69 @@
+using BabyNanny.Data;
+using BabyNanny.Models;
+using Microsoft.Maui.Controls;
+using System.Linq;
+
+namespace BabyNanny.Views;
+
+[QueryProperty(nameof(ChildId), "id")]
+public partial class AddChildPage : ContentPage
+{
+    private readonly BabyNannyRepository _repository;
+    private readonly ChildState _childState;
+    private Child _child = new();
+
+    public int ChildId { get; set; }
+
+    public AddChildPage()
+    {
+        InitializeComponent();
+        _repository = App.BabyNannyRepository!;
+        _childState = App.ChildState!;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (ChildId != 0)
+        {
+            var child = _childState.Children.FirstOrDefault(c => c.Id == ChildId) ??
+                         _repository.GetChildren()?.FirstOrDefault(c => c.Id == ChildId);
+            if (child != null)
+            {
+                _child = new Child { Id = child.Id, Name = child.Name, Birthday = child.Birthday };
+                nameEntry.Text = _child.Name;
+                if (child.Birthday.HasValue)
+                    birthdayPicker.Date = child.Birthday.Value;
+            }
+        }
+        else
+        {
+            _child = new Child();
+            nameEntry.Text = string.Empty;
+            birthdayPicker.Date = DateTime.Today;
+        }
+    }
+
+    private async void OnSaveClicked(object sender, EventArgs e)
+    {
+        _child.Name = nameEntry.Text;
+        _child.Birthday = birthdayPicker.Date;
+
+        if (_child.Id == 0)
+        {
+            _repository.AddChild(_child);
+        }
+        else
+        {
+            _repository.UpdateChild(_child);
+        }
+
+        _childState.AddOrUpdateChild(_child);
+        await Shell.Current.GoToAsync("..");
+    }
+
+    private async void OnCancelClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+}

--- a/BabyNanny/Views/SettingsPage.xaml
+++ b/BabyNanny/Views/SettingsPage.xaml
@@ -2,13 +2,22 @@
 <ContentPage
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:pages="clr-namespace:BabyNanny.Components.Pages"
+    xmlns:models="clr-namespace:BabyNanny.Models"
     x:Class="BabyNanny.Views.SettingsPage"
-    BackgroundColor="{DynamicResource PageBackgroundColor}"
-    Padding="20">
-    <BlazorWebView HostPage="wwwroot/index.html">
-        <BlazorWebView.RootComponents>
-            <RootComponent Selector="#app" ComponentType="{x:Type pages:Settings}" />
-        </BlazorWebView.RootComponents>
-    </BlazorWebView>
+    Title="Settings"
+    BackgroundColor="{DynamicResource PageBackgroundColor}">
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <CollectionView ItemsSource="{Binding Children}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:Child">
+                    <Grid ColumnDefinitions="*,Auto,Auto" Padding="5">
+                        <Label Text="{Binding Name}" />
+                        <Button Text="Edit" Grid.Column="1" Clicked="OnEditChild" />
+                        <Button Text="Delete" Grid.Column="2" Clicked="OnDeleteChild" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Button Text="Add Child" Clicked="OnAddChild" />
+    </VerticalStackLayout>
 </ContentPage>

--- a/BabyNanny/Views/SettingsPage.xaml.cs
+++ b/BabyNanny/Views/SettingsPage.xaml.cs
@@ -1,9 +1,57 @@
+using BabyNanny.Data;
+using BabyNanny.Models;
+using Microsoft.Maui.Controls;
+using System.Linq;
+
 namespace BabyNanny.Views;
 
 public partial class SettingsPage : ContentPage
 {
+    private readonly BabyNannyRepository _repository;
+    private readonly ChildState _childState;
+
     public SettingsPage()
     {
         InitializeComponent();
+        _repository = App.BabyNannyRepository!;
+        _childState = App.ChildState!;
+        BindingContext = _childState;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (_childState.Children.Count == 0)
+        {
+            var list = _repository.GetChildren();
+            if (list != null)
+                _childState.Children = list;
+        }
+    }
+
+    private async void OnAddChild(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync("addchild");
+    }
+
+    private async void OnEditChild(object sender, EventArgs e)
+    {
+        if ((sender as BindableObject)?.BindingContext is Child child)
+        {
+            await Shell.Current.GoToAsync($"addchild?id={child.Id}");
+        }
+    }
+
+    private async void OnDeleteChild(object sender, EventArgs e)
+    {
+        if ((sender as BindableObject)?.BindingContext is Child child)
+        {
+            bool confirm = await DisplayAlert("Delete Child", $"Delete {child.Name}?", "Delete", "Cancel");
+            if (confirm)
+            {
+                _repository.DeleteChild(child.Id);
+                _childState.RemoveChild(child.Id);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- reimplement SettingsPage with MAUI controls
- add AddChildPage for creating and editing children
- register new route in AppShell
- extend unit tests for BabyNannyRepository

## Testing
- `dotnet format BabyNanny.sln --no-restore`
- `dotnet test BabyNanny.sln --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_68553b92a6f08320beaae58f2c01f4ed