### PR TITLE
Fix iOS build by using smaller splash image

### DIFF
--- a/BabyNanny/BabyNanny.csproj
+++ b/BabyNanny/BabyNanny.csproj
@@ -41,7 +41,7 @@
     <!-- App Icon -->
     <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#b897af" />
     <!-- Splash Screen -->
-    <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#b897af" BaseSize="500,500" />
+    <MauiSplashScreen Include="Resources\Splash\splash_old.svg" Color="#b897af" BaseSize="500,500" />
     <!-- Images -->
     <MauiImage Include="Resources\Images\*" />
     <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />


### PR DESCRIPTION
## Summary
- switch MAUI splash screen to lighter `splash_old.svg` image

## Testing
- `dotnet format BabyNanny.sln --no-restore` *(fails: command produced no output)*
- `dotnet test BabyNanny.sln --no-build` *(fails: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd02c3008320b7315ab9f42da84c