### PR TITLE
Fix iOS build by removing splash screen

### DIFF
--- a/BabyNanny/BabyNanny.csproj
+++ b/BabyNanny/BabyNanny.csproj
@@ -40,8 +40,6 @@
   <ItemGroup>
     <!-- App Icon -->
     <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#b897af" />
-    <!-- Splash Screen -->
-    <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#b897af" BaseSize="500,500" />
     <!-- Images -->
     <MauiImage Include="Resources\Images\*" />
     <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />


### PR DESCRIPTION
## Summary
- remove the `<MauiSplashScreen>` entry from the MAUI project

## Testing
- `dotnet format BabyNanny.sln --no-restore` *(fails: command produced no output)*
- `dotnet test BabyNanny.sln --no-build` *(succeeds: build succeeded but no tests run)*


------
https://chatgpt.com/codex/tasks/task_e_6856fd02c3008320b7315ab9f42da84c